### PR TITLE
State why no panic should be raised when (re-)constructing a URL usin…

### DIFF
--- a/leptos-keycloak-auth/src/state.rs
+++ b/leptos-keycloak-auth/src/state.rs
@@ -93,7 +93,7 @@ pub fn current_url() -> Url {
     let current = use_url().get();
     // TODO: Why ignore search() / hash()?
     let current = format!("{}{}", current.origin(), current.path());
-    Url::parse(&current).unwrap()
+    Url::parse(&current).expect("Valid url constructed from `use_url` information.")
 }
 
 impl KeycloakAuth {


### PR DESCRIPTION
…g `use_url`