### PR TITLE
Track auth session version

### DIFF
--- a/leptos-keycloak-auth/src/components.rs
+++ b/leptos-keycloak-auth/src/components.rs
@@ -472,6 +472,9 @@ fn DebugStateInner() -> impl IntoView {
                 "token_data: " {move || format!("{:#?}", auth.token_manager().token.get())}
             </div>
             <div>
+                "session_version: " {move || format!("{:#?}", auth.token_manager().session_version.get())}
+            </div>
+            <div>
                 "access_token_lifetime: " {move || format!("{:?}", auth.token_manager().access_token_lifetime.get())}
             </div>
             <div>
@@ -494,9 +497,6 @@ fn DebugStateInner() -> impl IntoView {
             </div>
             <div>
                 "refresh_token_expired: " {move || format!("{:?}", auth.token_manager().refresh_token_expired.get())}
-            </div>
-            <div>
-                "token_endpoint: " {move || format!("{:?}", auth.token_manager().token_endpoint.get())}
             </div>
         </div>
     }

--- a/leptos-keycloak-auth/src/hooks.rs
+++ b/leptos-keycloak-auth/src/hooks.rs
@@ -262,6 +262,7 @@ fn real(options: UseKeycloakAuthOptions) -> KeycloakAuth {
                     // We have to make sure that the state is switched to `NotAuthenticated` (by observing that
                     // no token is present) first!
                     request_animation_frame(move || {
+                        // forget() handles generation increment to invalidate in-flight refreshes.
                         token_mgr.forget();
 
                         // We should recreate the code_verifier to have a new one for the next login phase.


### PR DESCRIPTION
Invalidate stale operations (detected when version was increased while waiting for asynchronous task)